### PR TITLE
fix renamed dependency

### DIFF
--- a/theia-yang-extension/src/frontend/monaco/yang-monaco-editor-provider.ts
+++ b/theia-yang-extension/src/frontend/monaco/yang-monaco-editor-provider.ts
@@ -18,7 +18,7 @@ import { MonacoWorkspace } from "@theia/monaco/lib/browser/monaco-workspace";
 import { MonacoCommandServiceFactory } from "@theia/monaco/lib/browser/monaco-command-service";
 import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
 import { QuickOpenService } from '@theia/core/lib/browser/quick-open/quick-open-service';
-import { MonacoDiffNavigatorFactory } from '@theia/monaco/lib/browser/monaco-diff-nagivator-factory';
+import { MonacoDiffNavigatorFactory } from '@theia/monaco/lib/browser/monaco-diff-navigator-factory';
 
 @injectable()
 export class YangMonacoEditorProvider extends MonacoEditorProvider {


### PR DESCRIPTION
In theia-ide/theia, a typo was fixed in a source file on which we depend.
The currently published "next" version of Theia has been published with
the correct name, so we need to use the new name.

fixes #56