### PR TITLE
Update yang-sprotty submodule and add theia-sprotty.css import

### DIFF
--- a/theia-yang-extension/src/frontend/yangdiagram/di.config.ts
+++ b/theia-yang-extension/src/frontend/yangdiagram/di.config.ts
@@ -11,6 +11,7 @@ import { DiagramConfiguration, EditDiagramLocker } from "sprotty-theia/lib"
 import { LSTheiaDiagramServer, LSTheiaDiagramServerProvider, TheiaDiagramServer, TheiaKeyTool } from 'sprotty-theia/lib'
 import { createYangDiagramContainer } from 'yang-sprotty/lib'
 import { YangDiagramServer } from "./yang-diagram-server"
+import 'sprotty-theia/css/theia-sprotty.css'
 
 @injectable()
 export class YangDiagramConfiguration implements DiagramConfiguration {


### PR DESCRIPTION
The import of sprotty-theia/css/theia-sprotty.css needs to be moved from yang-sprotty to theia-yang-extension.

See discussion: https://github.com/theia-ide/yang-eclipse/pull/22#discussion_r323636595